### PR TITLE
Add projection EPSG 2180 ETRF2000-PL / CS92

### DIFF
--- a/src/coordinate_projector/projections.json
+++ b/src/coordinate_projector/projections.json
@@ -1,4 +1,13 @@
 {
+  "2180": {
+    "srid": 2180,
+    "name": "ETRF2000-PL / CS92",
+    "shortname": "ETRF2000-PL CS92",
+    "definition": {
+      "name": "EPSG:2180",
+      "data": "+proj=tmerc +lat_0=0 +lon_0=19 +k=0.9993 +x_0=500000 +y_0=-5300000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs"
+    }
+  },
   "23030": {
     "srid": 23030,
     "name": "ED50 / UTM zone 30N",


### PR DESCRIPTION
  "2180": {
    "srid": 2180,
    "name": "ETRF2000-PL / CS92",
    "shortname": "ETRF2000-PL CS92",
    "definition": {
      "name": "EPSG:2180",
      "data": "+proj=tmerc +lat_0=0 +lon_0=19 +k=0.9993 +x_0=500000 +y_0=-5300000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs"
    }
  },